### PR TITLE
include style, css devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "assets-webpack-plugin": "^2.2.0",
     "babel-core": "^5.8.3",
     "babel-loader": "^5.3.2",
+    "css-loader": "^0.15.6",
+    "style-loader": "^0.12.3",
     "webpack": "^1.10.5"
   }
 }


### PR DESCRIPTION
can't run `webpack` from a clean install w/o them.
